### PR TITLE
Fix when add new objects in existing json

### DIFF
--- a/src/components/ProxyManager.tsx
+++ b/src/components/ProxyManager.tsx
@@ -213,7 +213,7 @@ const ProxyManager: VFC<ProxyManagerProps> = ({ orbitControlsRef }) => {
   return (
     <>
       <primitive object={sceneProxy} />
-      {selected && (
+      {selected && editableProxies[selected] && (
         <TransformControls
           mode={transformControlsMode}
           space={transformControlsSpace}

--- a/src/components/editable.tsx
+++ b/src/components/editable.tsx
@@ -139,7 +139,7 @@ const editable = <
                 );
             }
           },
-          (state) => state.editables[uniqueName].properties.transform
+          (state) => state.editables[uniqueName]?.properties?.transform
         );
 
         return () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -407,7 +407,7 @@ const config: StateCreator<EditorStore> = (set, get) => {
           {
             type: editable.type,
             properties: {
-              transform: editable.properties.transform.toArray(),
+              transform: editable.properties?.transform.toArray(),
             },
           },
         ])

--- a/src/store.ts
+++ b/src/store.ts
@@ -407,7 +407,24 @@ const config: StateCreator<EditorStore> = (set, get) => {
           {
             type: editable.type,
             properties: {
-              transform: editable.properties?.transform.toArray(),
+              transform: editable.properties?.transform.toArray() ?? [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+              ],
             },
           },
         ])


### PR DESCRIPTION
We couldn't add any new object when we were using an editable.json as the state.

This check prevents the browser to crash if we add new elements on top of the json.

Example : 
![image](https://user-images.githubusercontent.com/15867665/103271823-9da09600-49fe-11eb-9041-4a7090bfb03f.png)